### PR TITLE
Concurrẽncia, Tamanho de Ficheiros e AVF

### DIFF
--- a/src/Blocker/FileBlockInfo.java
+++ b/src/Blocker/FileBlockInfo.java
@@ -13,6 +13,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.io.Serializable;
 
+import Shared.*;
+
 public class FileBlockInfo implements Serializable
 {
     private Map<String, BlockInfo> fileBlockInfo;
@@ -46,7 +48,8 @@ public class FileBlockInfo implements Serializable
                 else 
                 {
                     Long fileSize = Files.size(filePath);
-                    fileBlockInfo.put(fileName, new BlockInfo(fileSize, null));
+                    Long nBlocks= fileSize/ Shared.Defines.blockSize;
+                    fileBlockInfo.put(fileName, new BlockInfo(nBlocks, null));
                 }
             }
         } 

--- a/src/Node/Node.java
+++ b/src/Node/Node.java
@@ -32,10 +32,15 @@ public class Node {
             AvfRepPacket packet = (AvfRepPacket) trackerInput.readObject();
 
             // Write File Names
-            List<String> files = packet.get_files();
-            for (String s : files) {
-                System.out.println(s);
+            Map<String, Long> files = packet.get_files();
+            System.out.println("Files:");
+
+            //Can be chaged latter (Better values for bigger files)
+            for (Map.Entry<String, Long> e : files.entrySet())
+            {
+                System.out.println(e.getKey()+ (e.getValue()*Shared.Defines.blockSize/1024)+ "kB");
             }
+
         } catch (IOException | ClassNotFoundException e) {
             e.printStackTrace();
         }
@@ -50,8 +55,6 @@ public class Node {
         try {
             trackerOutput.writeObject(new GetReqPacket(null, file));
             trackerOutput.flush();
-
-            // DEBUG!!!
 
             GetRepPacket resp = (GetRepPacket) trackerInput.readObject();
             Set<NetId> nodes = resp.get_nodeBlocks().keySet();

--- a/src/Server/ServerCom.java
+++ b/src/Server/ServerCom.java
@@ -48,7 +48,7 @@ public class ServerCom implements Runnable {
     private void handle_AVF_REQ() {
         System.out.println("AVF REQ");
         try {
-            out.writeObject(new AvfRepPacket(selfId, serverInfo.get_files()));
+            out.writeObject(new AvfRepPacket(selfId, serverInfo.get_filesWithSizes()));
             out.flush();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/Server/ServerInfo.java
+++ b/src/Server/ServerInfo.java
@@ -1,8 +1,6 @@
 package Server;
 
-import java.io.File;
 import java.util.*;
-
 import Blocker.BlockInfo;
 import Shared.NetId;
 
@@ -126,4 +124,18 @@ public class ServerInfo {
         }
     }
 
+    /**
+     * @return FileSizes mapped to corresponding filenames
+     */
+    public Map<String, Long> get_filesWithSizes ()
+    {
+        Map<String, Long> m= new HashMap<>();
+
+        for (Map.Entry<String, FileInfo> e : this.file_nodeData.entrySet())
+        {
+            m.put(e.getKey(), e.getValue().fileSize);
+        }
+
+        return m;
+    }
 }

--- a/src/Shared/Defines.java
+++ b/src/Shared/Defines.java
@@ -4,6 +4,6 @@ public class Defines
 {
     public static final int trackerPort= 9090;
     public static final int transferPort= 9090;
-    public static final int blocksize= 1024;
-    public static final int transferBuffer= blocksize+ 1024;
+    public static final int blockSize= 1024;
+    public static final int transferBuffer= blockSize+ 1024;
 }

--- a/src/TrackProtocol/AvfRepPacket.java
+++ b/src/TrackProtocol/AvfRepPacket.java
@@ -1,21 +1,20 @@
 package TrackProtocol;
 
 import Shared.NetId;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 
 public class AvfRepPacket extends TrackPacket
 {
-    List<String> files;
+    Map<String, Long> fileSizes;
 
-    public AvfRepPacket(NetId n, List<String> files) 
+    public AvfRepPacket(NetId n, Map<String, Long> files) 
     {
         super(n, TypeMsg.AVF_RESP);
-        this.files = new ArrayList<>(files);
+        this.fileSizes = files;
     }
 
-    public List<String> get_files() 
+    public Map<String, Long> get_files() 
     {
-        return new ArrayList<>(this.files);
+        return this.fileSizes;
     }    
 }


### PR DESCRIPTION
O node enviava o tamnho do ficheiro em bytes para o servidor.
AVF apresenta o tamanho do ficheiro (o tamanho é estimado a partir do nº de blocos).
Servidor preparado para acessos concorrentes à informação relativa aos nodes.

Fix #44, Fix #45, Fix #47